### PR TITLE
Upgrading subnet-evm to 0.2.7

### DIFF
--- a/vms/subnet-evm.yaml
+++ b/vms/subnet-evm.yaml
@@ -7,9 +7,9 @@ vm:
     - "patrickogrady@avalabs.org"
   installScript: "scripts/build.sh build/srEXiWaHuhNyGwPUi444Tu47ZEDwxTWrbQiuD7FmgSAQ6X7Dy"
   binaryPath: "build/srEXiWaHuhNyGwPUi444Tu47ZEDwxTWrbQiuD7FmgSAQ6X7Dy"
-  url: "https://github.com/ava-labs/subnet-evm/archive/refs/tags/v0.2.5.tar.gz"
-  sha256: "6b67d84f19380a932d7e5fc20d3f2fa22e4dcfd4eb63d84cac72378ab54daa12"
+  url: "https://github.com/ava-labs/subnet-evm/archive/refs/tags/v0.2.7.tar.gz"
+  sha256: "c0d63b56031820007cce5fa8ea635628b8b9a5897111290a78b60538838509f8"
   version:
     major: 0
     minor: 2
-    patch: 5
+    patch: 7

--- a/vms/subnet-evm.yaml
+++ b/vms/subnet-evm.yaml
@@ -7,9 +7,9 @@ vm:
     - "patrickogrady@avalabs.org"
   installScript: "scripts/build.sh build/srEXiWaHuhNyGwPUi444Tu47ZEDwxTWrbQiuD7FmgSAQ6X7Dy"
   binaryPath: "build/srEXiWaHuhNyGwPUi444Tu47ZEDwxTWrbQiuD7FmgSAQ6X7Dy"
-  url: "https://github.com/ava-labs/subnet-evm/archive/refs/tags/v0.2.7.tar.gz"
-  sha256: "c0d63b56031820007cce5fa8ea635628b8b9a5897111290a78b60538838509f8"
+  url: "https://github.com/ava-labs/subnet-evm/archive/refs/tags/v0.2.5.tar.gz"
+  sha256: "6b67d84f19380a932d7e5fc20d3f2fa22e4dcfd4eb63d84cac72378ab54daa12"
   version:
     major: 0
     minor: 2
-    patch: 7
+    patch: 5


### PR DESCRIPTION
Checksum:
```
➜  avalanchego-internal git:(vm-messaging) ✗ curl -Ls https://github.com/ava-labs/subnet-evm/archive/refs/tags/v0.2.7.tar.gz | openssl sha256
c0d63b56031820007cce5fa8ea635628b8b9a5897111290a78b60538838509f8
```

Testing:
```
➜  avalanche-plugins-core git:(unstable) apm upgrade
Detected an upgrade for unstable/avalanche-plugins-core:subnet-evm from v0.2.5 to v0.2.7.
Rebuilding binaries for unstable/avalanche-plugins-core:subnet-evm v0.2.7.
Downloading https://github.com/ava-labs/subnet-evm/archive/refs/tags/v0.2.7.tar.gz...
HTTP response 200 OK
  transferred 4653056 / -1 bytes (0.00%)
  transferred 12712584 / -1 bytes (0.00%)
  transferred 20979448 / -1 bytes (0.00%)
Calculating checksums...
Saw expected checksum value of c0d63b56031820007cce5fa8ea635628b8b9a5897111290a78b60538838509f8
Creating sources directory...
Unpacking unstable/avalanche-plugins-core:subnet-evm...
Running install script at scripts/build.sh build/srEXiWaHuhNyGwPUi444Tu47ZEDwxTWrbQiuD7FmgSAQ6X7Dy...
Using branch:
Building Subnet EVM Version: v0.2.7 at build/srEXiWaHuhNyGwPUi444Tu47ZEDwxTWrbQiuD7FmgSAQ6X7Dy
go: downloading github.com/ava-labs/avalanchego v1.7.16
Moving binary srEXiWaHuhNyGwPUi444Tu47ZEDwxTWrbQiuD7FmgSAQ6X7Dy into plugin directory...
Cleaning up temporary files...
Adding virtual machine srEXiWaHuhNyGwPUi444Tu47ZEDwxTWrbQiuD7FmgSAQ6X7Dy to installation registry...
Successfully installed unstable/avalanche-plugins-core:subnet-evm@v0.2.7 in /Users/joshua.kim/golang/src/github.com/ava-labs/avalanchego/build/plugins/srEXiWaHuhNyGwPUi444Tu47ZEDwxTWrbQiuD7FmgSAQ6X7Dy
```